### PR TITLE
Give user information about response body when status code is unexpected

### DIFF
--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -9,7 +9,8 @@ module Rack
       end
 
       def handle_error_code(code)
-        assert_equal(code, last_response.status)
+        assert_equal code, last_response.status,
+          "Expected #{code}, got #{last_response.status} - body #{last_response.body.empty? ? "empty" : last_response.body.pretty_inspect.chomp}"
 
         if @rack_test_rest[:debug]
           puts "Status: #{last_response.status}" if @rack_test_rest[:debug]


### PR DESCRIPTION
Replaces this:

```
<200> expected but was
<400>.
```

with this:

```
Expected 200, got 400 - body "{\"errors\":{\"params\":{\"value\":[\"is required\"],\"name\":\"foo_0\"}}}".
```

or this:

```
Expected 200, got 400 - body empty.
```
