### PR TITLE
Fix cleaning of rack-test-rest paths when bundler adds version.

### DIFF
--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -29,7 +29,7 @@ module Rack
       def with_clean_backtraces
         yield
       rescue MiniTest::Assertion => error
-        cleaned = error.backtrace.reject {|l| l.index('rack-test-rest/lib')}
+        cleaned = error.backtrace.reject {|l| l.index(/rack-test-rest[-.0-9]{0,}\/lib/)}
         error.set_backtrace(cleaned)
         raise
       end


### PR DESCRIPTION
When bundler installs this locally it will tack on the version number to the directory path, thereby breaking this match.

Example path: `/some/dir/.bundle/gems/ruby/1.9.1/gems/rack-test-rest-0.5.0/lib/rack-test-rest.rb`

This should match the conditional version string. /cc @nextmat
