### PR TITLE
Support using string params

### DIFF
--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -170,7 +170,8 @@ module Rack
       # split out common arguments & protect payload to ensure
       # we don't modify it by reference
       def _rtr_prepare_params(opts)
-        params = opts.dup
+        # symbolize all keys & ensure we don't affect original object
+        params = opts.each_with_object({}) { |(k,v),memo| memo[k.to_sym] = v }
         id = params.delete(:id)
         code = params.delete(:code)
         [id, code, params]

--- a/test/rack_test_rest_test.rb
+++ b/test/rack_test_rest_test.rb
@@ -76,4 +76,19 @@ class TestRackTestRest < Minitest::Test
     assert_equal original, payload
   end
 
+  def test_should_accept_string_params
+    # param parsing is DRYed up now, so testing one route
+    # should be adequate
+
+    update_resource('id' => 34, 'email' => 'fred@idk.com')
+
+    # request
+    assert last_request.put?
+    assert_equal '/v1/users/34', last_request.path
+    assert_equal 'fred@idk.com', last_request.params['email']
+
+    # response
+    assert_equal 204, last_response.status
+  end
+
 end


### PR DESCRIPTION
Accept string params as equivalent to symbol params in `create_resource`, etc.
