### PR TITLE
Feature/namespace

### DIFF
--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -18,14 +18,14 @@ module Rack
       def create_resource(params={})
         id, expected_code, params = _rtr_prepare_params(params)
 
-        puts "Posting to: '#{resource_uri}#{@rack_test_rest[:extension]}'" if @rack_test_rest[:debug]
+        puts "Posting to: '#{resource_uri}#{@rack_test_rest[:extension]}'" if _rtr_debug?
         post "#{resource_uri}#{@rack_test_rest[:extension]}", params
 
         _rtr_clean_backtraces do
 
           return _rtr_handle_code(expected_code) if expected_code
 
-          if @rack_test_rest[:debug]
+          if _rtr_debug?
             puts "#{last_response.status}: #{last_response.body}"
             puts last_response.original_headers["Location"]
           end
@@ -60,14 +60,14 @@ module Rack
           uri = "#{resource_uri}#{@rack_test_rest[:extension]}"
         end
 
-        puts "GET #{uri} #{params.inspect}" if @rack_test_rest[:debug]
+        puts "GET #{uri} #{params.inspect}" if _rtr_debug?
         get uri, params
 
         _rtr_clean_backtraces do
 
           return _rtr_handle_code(expected_code) if expected_code
 
-          if @rack_test_rest[:debug]
+          if _rtr_debug?
             puts "Code: #{last_response.status}"
             puts "Body: #{last_response.body}"
           end
@@ -83,13 +83,13 @@ module Rack
       def update_resource(params={})
         id, expected_code, params = _rtr_prepare_params(params)
 
-        puts "Attempting to update #{id} with #{params.inspect}" if @rack_test_rest[:debug]
+        puts "Attempting to update #{id} with #{params.inspect}" if _rtr_debug?
 
         put "#{resource_uri}/#{id}#{@rack_test_rest[:extension]}", params
 
         _rtr_clean_backtraces do
           return _rtr_handle_code(expected_code) if expected_code
-          puts "#{last_response.status}: #{last_response.body}" if @rack_test_rest[:debug]
+          puts "#{last_response.status}: #{last_response.body}" if _rtr_debug?
           assert_status_code(204)
         end
       end
@@ -140,7 +140,7 @@ module Rack
 
           expected_length = (length > (total - retrieved)) ? (total - retrieved) : length
 
-          if @rack_test_rest[:debug]
+          if _rtr_debug?
             puts "Requesting offset='#{offset}', length='#{length}'"
             puts "Expecting '#{expected_length}'"
           end
@@ -149,10 +149,10 @@ module Rack
           pg_resp = read_resource(get_params)
 
           _rtr_clean_backtraces do
-            puts "Received #{pg_resp[@rack_test_rest[:resource]].count} records" if @rack_test_rest[:debug]
+            puts "Received #{pg_resp[@rack_test_rest[:resource]].count} records" if _rtr_debug?
             assert_equal(expected_length, pg_resp[@rack_test_rest[:resource]].count)
 
-            puts "Found #{pg_resp["query"]["found"]} records" if @rack_test_rest[:debug]
+            puts "Found #{pg_resp["query"]["found"]} records" if _rtr_debug?
             assert_equal(total, pg_resp["query"]["found"])
 
             assert_equal(total, pg_resp["query"]["total"])
@@ -166,6 +166,10 @@ module Rack
       end
 
     private
+
+      def _rtr_debug?
+        @rack_test_rest[:debug]
+      end
 
       # split out common arguments & protect payload to ensure
       # we don't modify it by reference
@@ -191,7 +195,7 @@ module Rack
       def _rtr_handle_code(code)
         assert_status_code(code)
 
-        if @rack_test_rest[:debug]
+        if _rtr_debug?
           puts "Status: #{last_response.status}"
           puts "Headers:"
           puts last_response.headers.inspect

--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -9,7 +9,7 @@ module Rack
       # if needed.
       #
       def resource_uri
-        "#{@rack_test_rest[:root_uri]}/#{@rack_test_rest[:resource]}"
+        "#{_rtr(:root_uri)}/#{_rtr(:resource)}"
       end
 
       # create a new instance of the given resource, expecting a 201
@@ -18,8 +18,8 @@ module Rack
       def create_resource(params={})
         id, expected_code, params = _rtr_prepare_params(params)
 
-        puts "Posting to: '#{resource_uri}#{@rack_test_rest[:extension]}'" if _rtr_debug?
-        post "#{resource_uri}#{@rack_test_rest[:extension]}", params
+        puts "Posting to: '#{resource_uri}#{_rtr(:extension)}'" if _rtr_debug?
+        post "#{resource_uri}#{_rtr(:extension)}", params
 
         _rtr_clean_backtraces do
 
@@ -33,10 +33,10 @@ module Rack
           assert_status_code(201)
           assert_content_type_is_json
 
-          if @rack_test_rest[:location]
-            assert last_response.original_headers["Location"] =~ @rack_test_rest[:location],
+          if _rtr(:location)
+            assert last_response.original_headers["Location"] =~ _rtr(:location),
               "Response location header '%s' does not match RegExp '%s'" %
-              [last_response.original_headers["Location"], @rack_test_rest[:location]]
+              [last_response.original_headers["Location"], _rtr(:location)]
           end
 
         end
@@ -55,9 +55,9 @@ module Rack
         id, expected_code, params = _rtr_prepare_params(params)
 
         if id
-          uri = "#{resource_uri}/#{id}#{@rack_test_rest[:extension]}"
+          uri = "#{resource_uri}/#{id}#{_rtr(:extension)}"
         else
-          uri = "#{resource_uri}#{@rack_test_rest[:extension]}"
+          uri = "#{resource_uri}#{_rtr(:extension)}"
         end
 
         puts "GET #{uri} #{params.inspect}" if _rtr_debug?
@@ -85,7 +85,7 @@ module Rack
 
         puts "Attempting to update #{id} with #{params.inspect}" if _rtr_debug?
 
-        put "#{resource_uri}/#{id}#{@rack_test_rest[:extension]}", params
+        put "#{resource_uri}/#{id}#{_rtr(:extension)}", params
 
         _rtr_clean_backtraces do
           return _rtr_handle_code(expected_code) if expected_code
@@ -103,7 +103,7 @@ module Rack
 
       def delete_resource(params={})
         id, code, params = _rtr_prepare_params(params)
-        delete "#{resource_uri}/#{id}#{@rack_test_rest[:extension]}"
+        delete "#{resource_uri}/#{id}#{_rtr(:extension)}"
 
         _rtr_clean_backtraces do
           return _rtr_handle_code(code) if code
@@ -149,8 +149,8 @@ module Rack
           pg_resp = read_resource(get_params)
 
           _rtr_clean_backtraces do
-            puts "Received #{pg_resp[@rack_test_rest[:resource]].count} records" if _rtr_debug?
-            assert_equal(expected_length, pg_resp[@rack_test_rest[:resource]].count)
+            puts "Received #{pg_resp[_rtr(:resource)].count} records" if _rtr_debug?
+            assert_equal(expected_length, pg_resp[_rtr(:resource)].count)
 
             puts "Found #{pg_resp["query"]["found"]} records" if _rtr_debug?
             assert_equal(total, pg_resp["query"]["found"])
@@ -167,8 +167,14 @@ module Rack
 
     private
 
+      # easy access to internal properties
+      def _rtr(key)
+        @rack_test_rest[key]
+      end
+
+      # debug mode?
       def _rtr_debug?
-        @rack_test_rest[:debug]
+        !!@rack_test_rest[:debug]
       end
 
       # split out common arguments & protect payload to ensure

--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -21,9 +21,9 @@ module Rack
         puts "Posting to: '#{resource_uri}#{@rack_test_rest[:extension]}'" if @rack_test_rest[:debug]
         post "#{resource_uri}#{@rack_test_rest[:extension]}", params
 
-        with_clean_backtraces do
+        _rtr_clean_backtraces do
 
-          return handle_error_code(expected_code) if expected_code
+          return _rtr_handle_code(expected_code) if expected_code
 
           if @rack_test_rest[:debug]
             puts "#{last_response.status}: #{last_response.body}"
@@ -63,9 +63,9 @@ module Rack
         puts "GET #{uri} #{params.inspect}" if @rack_test_rest[:debug]
         get uri, params
 
-        with_clean_backtraces do
+        _rtr_clean_backtraces do
 
-          return handle_error_code(expected_code) if expected_code
+          return _rtr_handle_code(expected_code) if expected_code
 
           if @rack_test_rest[:debug]
             puts "Code: #{last_response.status}"
@@ -87,8 +87,8 @@ module Rack
 
         put "#{resource_uri}/#{id}#{@rack_test_rest[:extension]}", params
 
-        with_clean_backtraces do
-          return handle_error_code(expected_code) if expected_code
+        _rtr_clean_backtraces do
+          return _rtr_handle_code(expected_code) if expected_code
           puts "#{last_response.status}: #{last_response.body}" if @rack_test_rest[:debug]
           assert_status_code(204)
         end
@@ -105,8 +105,8 @@ module Rack
         id, code, params = _rtr_prepare_params(params)
         delete "#{resource_uri}/#{id}#{@rack_test_rest[:extension]}"
 
-        with_clean_backtraces do
-          return handle_error_code(code) if code
+        _rtr_clean_backtraces do
+          return _rtr_handle_code(code) if code
           assert_status_code(204)
         end
       end
@@ -148,7 +148,7 @@ module Rack
           get_params = read_params.merge(offset: offset, length: length)
           pg_resp = read_resource(get_params)
 
-          with_clean_backtraces do
+          _rtr_clean_backtraces do
             puts "Received #{pg_resp[@rack_test_rest[:resource]].count} records" if @rack_test_rest[:debug]
             assert_equal(expected_length, pg_resp[@rack_test_rest[:resource]].count)
 
@@ -188,7 +188,7 @@ module Rack
           "Expected status #{code}, but got a #{last_response.status}.\nBody: #{last_response.body.empty? ? "empty" : last_response.body.inspect.chomp}"
       end
 
-      def handle_error_code(code)
+      def _rtr_handle_code(code)
         assert_status_code(code)
 
         if @rack_test_rest[:debug]
@@ -208,7 +208,7 @@ module Rack
 
       # remove library lines from call stack so error is reported
       # where the call to rack-test-rest is being made
-      def with_clean_backtraces
+      def _rtr_clean_backtraces
         yield
       rescue MiniTest::Assertion => error
         cleaned = error.backtrace.reject do |line|


### PR DESCRIPTION
- Namespace private methods with `_rtr` since they are injected into scope when they are included & are a collision risk
- DRY up debug calls into `_rtr_debug?`
- DRY up `@rack_test_rest` var access into `_rtr` accessor method
