### PR TITLE
Bugfix/skip

### DIFF
--- a/lib/rack-test-rest.rb
+++ b/lib/rack-test-rest.rb
@@ -16,7 +16,7 @@ module Rack
       # unless the :code option is specified.
       #
       def create_resource(params={})
-        id, expected_code, params = _rtr_prepare_params(params)
+        expected_code, params = _rtr_prepare_params(params, no_id: true)
 
         puts "Posting to: '#{resource_uri}#{@rack_test_rest[:extension]}'" if @rack_test_rest[:debug]
         post "#{resource_uri}#{@rack_test_rest[:extension]}", params
@@ -169,12 +169,14 @@ module Rack
 
       # split out common arguments & protect payload to ensure
       # we don't modify it by reference
-      def _rtr_prepare_params(opts)
+      def _rtr_prepare_params(params, opts={})
         # symbolize all keys & ensure we don't affect original object
-        params = opts.each_with_object({}) { |(k,v),memo| memo[k.to_sym] = v }
-        id = params.delete(:id)
-        code = params.delete(:code)
-        [id, code, params]
+        prep = params.each_with_object({}) { |(k,v),memo| memo[k.to_sym] = v }
+        result = []
+        result << prep.delete(:id) unless opts[:no_id]
+        result << prep.delete(:code)
+        result << prep
+        result
       end
 
       def assert_content_type_is_json(response=last_response)

--- a/test/fixtures/sample_app.rb
+++ b/test/fixtures/sample_app.rb
@@ -10,6 +10,7 @@ module Rack::Test::Rest
     end
 
     post '/v1/users' do
+      status 201
       headers 'Content-Type' => 'application/json'
       body '{}'
     end

--- a/test/rack_test_rest_test.rb
+++ b/test/rack_test_rest_test.rb
@@ -27,6 +27,11 @@ class TestRackTestRest < Minitest::Test
     assert_equal 201, last_response.status
   end
 
+  def test_create_resource_should_pass_id
+    create_resource(id: 101, email: 'fred@sinatra.com', password: 'groovy')
+    assert_equal "101", last_request.params['id']
+  end
+
   def test_read_resource
     read_resource(id: 15)
 

--- a/test/rack_test_rest_test.rb
+++ b/test/rack_test_rest_test.rb
@@ -16,6 +16,17 @@ class TestRackTestRest < Minitest::Test
     }
   end
 
+  def test_create_resource
+    create_resource(email: 'fred@sinatra.com', password: 'groovy')
+
+    # request
+    assert last_request.post?
+    assert_equal '/v1/users', last_request.path
+
+    # response
+    assert_equal 201, last_response.status
+  end
+
   def test_read_resource
     read_resource(id: 15)
 


### PR DESCRIPTION
`create_resource` should pass-through id when set.

Also adds basic test coverage for `create_resource`.
